### PR TITLE
Added support for --const/k lsc flag.

### DIFF
--- a/example/bad-constants.ls
+++ b/example/bad-constants.ls
@@ -1,0 +1,4 @@
+x = 1
+x = 2
+x = 3
+console.log x

--- a/example/constants.ls
+++ b/example/constants.ls
@@ -1,0 +1,4 @@
+x = 1
+y = 2
+z = 3
+console.log x + y + z

--- a/index.js
+++ b/index.js
@@ -1,14 +1,31 @@
 var LiveScript = require('LiveScript');
 var through = require('through');
+
+// Compile all variables as constants if the LSC_CONST
+// environment variable is set to "true"
+var k = process.env.LSC_CONST === 'true';
+
+// Consider files as livescript if they end in ".ls"
+var IS_LS = /\.ls$/i;
+
 module.exports = function (file) {
-    if (!/\.ls/.test(file)) return through();
+    if (!IS_LS.test(file)) return through();
     
     var data = '';
     return through(write, end);
     
     function write (buf) { data += buf }
     function end () {
-        this.queue(LiveScript.compile(data,{filename:file,bare:true}));
+        try {
+          var js = LiveScript.compile(data, {
+            'filename': file,
+            'const': k,
+            'bare': true
+          });
+          this.queue(js);
+        } catch (e) {
+          this.emit('error', e);
+        }
         this.queue(null);
     }
 };

--- a/readme.markdown
+++ b/readme.markdown
@@ -50,6 +50,16 @@ With [npm](https://npmjs.org) do:
 npm install liveify
 ```
 
+# options
+
+By default livescript is compiled with the constant flag set to
+false. This can be set to true by setting the environment
+variable `LSC_CONST`:
+
+```
+LSC_CONST=true browserify -t liveify -e my-app.ls > my-app.js
+```
+
 # license
 
 MIT

--- a/test/constants.js
+++ b/test/constants.js
@@ -1,0 +1,46 @@
+var test = require('tap').test;
+var browserify = require('browserify');
+var vm = require('vm');
+
+test('good constants', function (t) {
+    t.plan(1);
+    
+    process.env.LSC_CONST = 'true';
+    var b = browserify();
+    b.add(__dirname + '/../example/constants.ls');
+    b.transform(__dirname + '/..');
+    b.bundle(function (err, src) {
+        if (err) return t.fail(err);
+        vm.runInNewContext(src, {
+            console: { log: log }
+        });
+    });
+    
+    function log (msg) {
+        t.equal(msg, 6);
+    }
+});
+
+test('bad constants', function (t) {
+    t.plan(2);
+    
+    process.env.LSC_CONST = 'true';
+    var b = browserify();
+    b.add(__dirname + '/../example/bad-constants.ls');
+    b.transform(__dirname + '/..');
+    try {
+      b.bundle(function (err, src) {
+          if (err) {
+            t.ok(err !== null, "There is an error");
+            t.ok(
+              /redeclaration/.test(String(err)),
+              "... which mentions the constant pragma"
+            );
+          } else {
+            t.fail("Expected error, got: " + src);
+          }
+      });
+    } catch (e) {
+      t.fail("Error thrown by bundle: " + e);
+    }
+});


### PR DESCRIPTION
Some people choose to compile with the const flag set. This enables that option in liveify, by using environment variables to hold this option.

This pull request includes tests for this feature, including for error conditions.

I also took the liberty of fixing the regexp used to test for the ls extension (it would match anywhere in the filename).
