### PR TITLE
Added LiveScript package to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "tap": "~0.4.0",
     "browserify": "~2.4.0"
   },
+  "peerDependencies": {
+    "LiveScript": "~1.3.1"
+  },
   "scripts": {
     "test": "tap test/*.js"
   },


### PR DESCRIPTION
For using custom LiveScript version. Also LiveScript maintainer doesn't using semver and LiveScript can brake backward compatibility in any next release and with peer dependency we can set fixed LiveScript version if we need it.